### PR TITLE
Improvement: Tighter bounds for window in aspiration window search be…

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -87,7 +87,7 @@ fn aspiration_window(board: &Board, max_depth: u8, estimate: i32, data: &mut Sea
             return score;
         }
 
-        delta += delta / 2;
+        delta += 2 * delta / 5;
         if delta > ASPIRATION_DELTA_LIMIT {
             alpha = -INF;
             beta = INF;


### PR DESCRIPTION
Results of test vs main (8+0.08, 1t, 32MB, Pohl.epd):
Elo: 3.27 +/- 2.42, nElo: 4.97 +/- 3.68
LOS: 99.60 %, DrawRatio: 41.34 %, PairsRatio: 1.05
Games: 34278, Wins: 9170, Losses: 8847, Draws: 16261, Points: 17300.5 (50.47 %)
Ptnml(0-2): [754, 4161, 7085, 4286, 853], WL/DD Ratio: 0.81
LLR: 2.96 (100.4%) (-2.94, 2.94) [0.00, 3.00]