### PR TITLE
Simplify castling logic based on a 64 precomputed array

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -1,3 +1,4 @@
+use crate::castle::CASTLE_MASK;
 use crate::constants::{queen_attacks, FILE_A, FILE_H};
 use crate::network::{EvalTable, Network};
 use crate::{
@@ -103,30 +104,11 @@ impl Board {
             self.halfmoves += 1;
         }
 
-        if src_piece.is_king() {
-            if src_piece.colour() == Colour::White {
-                let new_rights =
-                    CastlingRights(old_rights.0 & !(CastlingRights::WK | CastlingRights::WQ));
-                self.castling_rights = new_rights;
-                self.hash.swap_castle(old_rights, new_rights);
-            } else {
-                let new_rights =
-                    CastlingRights(old_rights.0 & !(CastlingRights::BK | CastlingRights::BQ));
-                self.castling_rights = new_rights;
-                self.hash.swap_castle(old_rights, new_rights);
-            }
-        } else if src_piece.is_rook() {
-            let new_rights = match (src_piece.colour(), src.index()) {
-                (Colour::White, 0) => CastlingRights(old_rights.0 & !CastlingRights::WQ), // a1
-                (Colour::White, 7) => CastlingRights(old_rights.0 & !CastlingRights::WK), // h1
-                (Colour::Black, 56) => CastlingRights(old_rights.0 & !CastlingRights::BQ), // a8
-                (Colour::Black, 63) => CastlingRights(old_rights.0 & !CastlingRights::BK), // h8
-                _ => old_rights,
-            };
-            if new_rights != old_rights {
-                self.castling_rights = new_rights;
-                self.hash.swap_castle(old_rights, new_rights);
-            }
+        let new_rights =
+            CastlingRights(old_rights.0 & CASTLE_MASK[src.index()] & CASTLE_MASK[dest.index()]);
+        if new_rights != old_rights {
+            self.castling_rights = new_rights;
+            self.hash.swap_castle(old_rights, new_rights);
         }
 
         match move_type {

--- a/src/castle.rs
+++ b/src/castle.rs
@@ -46,3 +46,14 @@ impl CastlingRights {
         right
     }
 }
+
+pub const CASTLE_MASK: [u8; 64] = {
+    let mut m = [0xFF_u8; 64];
+    m[0] = !CastlingRights::WQ;
+    m[4] = !(CastlingRights::WK | CastlingRights::WQ);
+    m[7] = !CastlingRights::WK;
+    m[56] = !CastlingRights::BQ;
+    m[60] = !(CastlingRights::BK | CastlingRights::BQ);
+    m[63] = !CastlingRights::BK;
+    m
+};


### PR DESCRIPTION
Elo: 1.79 +/- 2.90, nElo: 2.61 +/- 3.05
LOS: 95.36%, DrawRatio: 40.78 %, PairsRatio: 1.03
Games: 50000, Wins: 14000, Losses: 13743, Draws: 22258, Points: 25129.0 (50.26 %)
Ptnml(0-2): [1439, 5856, 10195, 6028, 1482], WL/DD Ratio: 0.97
LLR: 1.38 (46.9%) (-2.94, 2.94) [0.00, 3.00]