### PR TITLE
Adjust return value for beta_cutoff in rfp 

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -211,7 +211,7 @@ fn negamax(board: &Board, mut depth: u8, mut alpha: i32, beta: i32, data: &mut S
         let rfp_margin = RFP_MARGIN * depth as i32 - RFP_IMPROVING * improving as i32;
 
         if depth <= RFP_DEPTH && static_eval - rfp_margin >= beta {
-            return static_eval;
+            return (static_eval + beta) / 2;
         }
 
         // Razoring


### PR DESCRIPTION
Elo: 3.58 +/- 2.63, nElo: 5.09 +/- 3.74
LOS: 99.62 %, DrawRatio: 39.91 %, PairsRatio: 1.05
Games: 33180, Wins: 9734, Losses: 9392, Draws: 14054, Points: 16761.0 (50.52 %)
Ptnml(0-2): [1039, 3814, 6621, 3998, 1118], WL/DD Ratio: 1.12
LLR: 2.96 (100.5%) (-2.94, 2.94) [0.00, 3.00]