### PR TITLE
Remove evalcache reinitialization on every iteration

### DIFF
--- a/src/uci.rs
+++ b/src/uci.rs
@@ -135,7 +135,6 @@ impl UCIEngine {
 
     fn go(&mut self, args: &[&str]) {
         self.data.tt.inc_age();
-        self.data.cache = EvalTable::default();
         let mut depth: u8 = 64;
         let mut wtime: Option<usize> = None;
         let mut btime: Option<usize> = None;


### PR DESCRIPTION
Elo: 4.00 +/- 2.77, nElo: 6.12 +/- 4.25
LOS: 99.76 %, DrawRatio: 41.69 %, PairsRatio: 1.08
Games: 25728, Wins: 6891, Losses: 6595, Draws: 12242, Points: 13012.0 (50.58 %)
Ptnml(0-2): [574, 3036, 5363, 3302, 589], WL/DD Ratio: 0.82
LLR: 2.95 (100.2%) (-2.94, 2.94) [0.00, 3.00]
(8+0.08, 1t, 32MB, Pohl.epd)