### PR TITLE
remove is_attacked_by, simplify in_check using stored checkers bitboard

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -383,7 +383,7 @@ impl Board {
     }
 
     pub fn in_check(&self) -> bool {
-        self.is_attacked_by(self.king_square(self.side as usize), !self.side)
+        self.checkers != BitBoard::EMPTY
     }
 
     pub fn make_null_move(&mut self) {
@@ -397,25 +397,6 @@ impl Board {
 
         self.calculate_threats();
         self.pinned_and_checkers();
-    }
-
-    /// Returns whether the given square is attacked by the given side or not,
-    /// it uses sliding for bishop-queen and pawn, Obstruction difference with Infuehr improvement
-    /// and precalculated bitboards for Knights and Kings
-    pub fn is_attacked_by(&self, square: Square, attacker: Colour) -> bool {
-        let idx = square.index();
-        let enemy_side = self.sides[attacker as usize];
-        let occ = self.sides[Colour::White as usize] | self.sides[Colour::Black as usize];
-
-        ((KNIGHT_ATTACKS[idx] & self.pieces[Piece::WN.index()])
-            | (KING_ATTACKS[idx] & self.pieces[Piece::WK.index()])
-            | (PAWN_ATTACKS[!attacker as usize][idx] & self.pieces[Piece::WP.index()])
-            | (rook_attacks(occ.0, idx)
-                & (self.pieces[Piece::WR.index()] | self.pieces[Piece::WQ.index()]))
-            | (bishop_attacks(occ.0, idx)
-                & (self.pieces[Piece::WB.index()] | self.pieces[Piece::WQ.index()])))
-            & enemy_side
-            != BitBoard::EMPTY
     }
 
     pub fn is_king_pawn(&self) -> bool {


### PR DESCRIPTION
Elo: 4.67 +/- 3.06, nElo: 7.13 +/- 4.68
LOS: 99.86 %, DrawRatio: 41.81 %, PairsRatio: 1.08
Games: 21200, Wins: 5684, Losses: 5399, Draws: 10117, Points: 10742.5 (50.67 %)
Ptnml(0-2): [459, 2512, 4432, 2679, 518], WL/DD Ratio: 0.80
LLR: 2.97 (100.7%) (-2.94, 2.94) [0.00, 3.00]
(8+0.08, 1t, 32MB, Pohl.epd)