### PR TITLE
Add NMP margin tweak bench 6787323

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -223,7 +223,8 @@ fn negamax(board: &Board, mut depth: u8, mut alpha: i32, beta: i32, data: &mut S
         }
 
         // Null Move Pruning
-        if depth >= NMP_MIN_DEPTH && !board.is_king_pawn() {
+        let nmp_margin = 9 * depth as i32 - 266 + (improving as i32 >> 3);
+        if depth >= NMP_MIN_DEPTH && !board.is_king_pawn() && static_eval >= beta + nmp_margin {
             let mut null_board = *board;
             null_board.make_null_move();
             let r = (NMP_BASE_REDUCTION + depth / NMP_DIVISOR).min(depth);


### PR DESCRIPTION
STC | Elo 1.16 (-2.72 / +2.72) nElo 1.68 (-3.94 / +3.94)
BayesElo 1.59 (-3.74 / +3.74) [-2.15 to 5.33] DrawElo 200.53
LOS 79.80% W/L Ratio 1.01 Draw Ratio 0.52 LLR -0.1308
Bench: 6787323